### PR TITLE
ptvl beacon

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -9,6 +9,7 @@
 <extension point="xbmc.python.pluginsource" library="addon.py">
   <provides>video</provides>
 </extension>
+<extension point="xbmc.service" library="pseudotv_recommended.py"/>
 <extension point="xbmc.addon.metadata">
   <summary lang="en">discovery+</summary>
   <description lang="en"></description>

--- a/pseudotv_recommended.py
+++ b/pseudotv_recommended.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""PseudoTV Live / IPTV Manager Integration module"""
+import os, re, json
+import xbmcaddon, xbmcgui
+
+# Manager Info
+IPTV_MANAGER = xbmcaddon.Addon(id='service.iptv.manager')
+IPTV_PATH    = IPTV_MANAGER.getAddonInfo('profile')
+IPTV_M3U     = os.path.join(IPTV_PATH,'playlist.m3u8')
+IPTV_XMLTV   = os.path.join(IPTV_PATH,'epg.xml')
+
+# Plugin Info
+ADDON_ID      = 'plugin.video.discoveryplus'
+PROP_KEY      = 'PseudoTV_Recommended.%s'%(ADDON_ID)
+REAL_SETTINGS = xbmcaddon.Addon(id=ADDON_ID)
+ADDON_NAME    = REAL_SETTINGS.getAddonInfo('name')
+ADDON_PATH    = REAL_SETTINGS.getAddonInfo('path')
+ICON          = REAL_SETTINGS.getAddonInfo('icon')
+MONITOR       = xbmc.Monitor()
+
+def slugify(text):
+    non_url_safe = [' ','"', '#', '$', '%', '&', '+',',', '/', ':', ';', '=', '?','@', '[', '\\', ']', '^', '`','{', '|', '}', '~', "'"]
+    non_url_safe_regex = re.compile(r'[{}]'.format(''.join(re.escape(x) for x in non_url_safe)))
+    text = non_url_safe_regex.sub('', text).strip()
+    text = u'_'.join(re.split(r'\s+', text))
+    return text
+
+def regPseudoTV():
+    while not MONITOR.abortRequested():
+        if REAL_SETTINGS.getSettingBool('iptv.enabled'):
+            asset = {'type':'iptv','name':ADDON_NAME,'path':ADDON_PATH,'icon':ICON.replace(ADDON_PATH,'special://home/addons/%s/'%(ADDON_ID)).replace('\\','/'),'m3u':{'path':IPTV_M3U,'slug':'@%s'%(slugify(ADDON_NAME))},'xmltv':{'path':IPTV_XMLTV},'id':ADDON_ID}
+            xbmcgui.Window(10000).setProperty(PROP_KEY, json.dumps(asset))
+        else:
+            xbmcgui.Window(10000).clearProperty(PROP_KEY)
+        if MONITOR.waitForAbort(900): break
+if __name__ == '__main__': regPseudoTV()

--- a/resources/lib/dplay.py
+++ b/resources/lib/dplay.py
@@ -13,6 +13,7 @@ import calendar
 from datetime import datetime, timedelta, date
 import requests
 import uuid
+import xbmcaddon
 
 try: # Python 3
     import http.cookiejar as cookielib
@@ -29,7 +30,14 @@ try:  # Python 2
     unicode
 except NameError:  # Python 3
     unicode = str  # pylint: disable=redefined-builtin,invalid-name
-
+    
+def slugify(text):
+    non_url_safe = [' ','"', '#', '$', '%', '&', '+',',', '/', ':', ';', '=', '?','@', '[', '\\', ']', '^', '`','{', '|', '}', '~', "'"]
+    non_url_safe_regex = re.compile(r'[{}]'.format(''.join(re.escape(x) for x in non_url_safe)))
+    text = non_url_safe_regex.sub('', text).strip()
+    text = u'_'.join(re.split(r'\s+', text))
+    return text
+    
 class Dplay(object):
     def __init__(self, settings_folder, site, locale, logging_prefix, numresults, cookiestxt, cookiestxt_file):
         self.logging_prefix = logging_prefix
@@ -450,7 +458,7 @@ class Dplay(object):
             url = 'plugin://plugin.video.discoveryplus/?action=play&video_id={channel_id}&video_type=channel'.format(channel_id=value['id'])
 
             channels_list.append(dict(
-                id=key,
+                id='%s@%s'%(key,slugify(xbmcaddon.Addon(id='plugin.video.discoveryplus').getAddonInfo('name'))),
                 name=value['logo']['title'],
                 logo=value['logo']['src'],
                 stream=url,


### PR DESCRIPTION
If you are interested...  I have a project called PseudoTV Live, it turns Kodis VFS into emulated LiveTV, it also supports importing live sources via a broadcast beacon with meta; In this case a m3u/xmltv. Recently I moved over to IPTV Manager to handle m3u/xmltv building/merging. 

If you want to add support, my changes are simple... a beacon to let PseudoTV Live know your plugin is installed and setup for IPTV Manager, and a more robust channel id, which needs to be indicated in the beacon. It can be anything but for convenience a slug of the plugin name works best.

Feel free to contact me if you are interested, have any questions... related or not; take care... and Kudos on this project!