### PR TITLE
Enable UHD quality on Discovery+ US

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -124,3 +124,11 @@ msgstr ""
 msgctxt "#30027"
 msgid "Sync to Discovery+"
 msgstr ""
+
+msgctxt "#30028"
+msgid "Use InputStream Adaptive"
+msgstr ""
+
+msgctxt "#30029"
+msgid "Enable UHD"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -10,6 +10,8 @@
     <setting id="password" type="text" label="30016" option="hidden" default="" enable="eq(-3,false)"/>
     <setting id="reset_credentials" type="action" label="30005" action="RunPlugin(plugin://plugin.video.discoveryplus/?setting=reset_credentials)" enable="eq(-4,false)"/>
     <setting id="sync_playback" label="30027" type="bool" default="true"/>
+    <setting id="us_uhd" label="30029" type="bool" default="false" visible="eq(-9,discoveryplus.com)"/>
+    <setting id="use_isa" label="30028" type="bool" default="true" enable="eq(-1,true)"/>
   </category>
     <category label="30023">
         <setting label="30024" type="action" action="InstallAddon(service.iptv.manager)" option="close" visible="!System.HasAddon(service.iptv.manager)"/>


### PR DESCRIPTION
I'm not sure if other regions have UHD/4k content, but US has some UHD content. According to https://help.discoveryplus.com/hc/en-us/articles/1500000317922-Watching-video-in-Ultra-HD they are currently available on Fire TV and Apple TV. I found out that by setting platform to firetv and telling it that hardware decoding of h265 is available, it will send a different m3u8 file that has HEVC 2160p video.

I would call this a beta feature. In my testing, if I try to skip forward, it won't work and the video will stop playing. Same with trying to resume a video, it can only be started from the beginning. Also having issues when playing UHD videos through InputStream Adaptive. It gives an error while trying to load the subtitle file (403 error) and then stops trying to load the video and I have to kill Kodi from task manager. So I also added an option to disable using InputStream Adaptive. When I allow Kodi to load the UHD video file, it loads.