### PR TITLE
fix issue with flicker on discoveryplus.com

### DIFF
--- a/resources/lib/dplay.py
+++ b/resources/lib/dplay.py
@@ -833,6 +833,7 @@ class Dplay(object):
 
         # discoveryplus.com (US)
         if self.locale_suffix == 'us':
+            # discoveryplus.com has frame-rate="30.000" even though videos are 29.970 fps. This downloads the m3u8 and changes 30.000 to 29.970
             originalm3u8 = requests.get(data_dict['attributes']['streaming'][0]['url']).text
             updatedm3u8 = originalm3u8.replace("30.000", "29.970")
             tempm3u8 = open(self.tempdir + "temp.m3u8", "w")

--- a/resources/lib/dplay.py
+++ b/resources/lib/dplay.py
@@ -833,7 +833,13 @@ class Dplay(object):
 
         # discoveryplus.com (US)
         if self.locale_suffix == 'us':
-            stream['hls_url'] = data_dict['attributes']['streaming'][0]['url']
+            originalm3u8 = requests.get(data_dict['attributes']['streaming'][0]['url']).text
+            updatedm3u8 = originalm3u8.replace("30.000", "29.970")
+            tempm3u8 = open(self.tempdir + "temp.m3u8", "w")
+            tempm3u8.write(updatedm3u8)
+            tempm3u8.close()
+            tempm3u8path = self.tempdir.replace("\\", "/") #replace backslashes in path with frontslashes on windows or ISA fails to load path
+            stream['hls_url'] = tempm3u8path + "temp.m3u8"
             stream['drm_enabled'] = data_dict['attributes']['streaming'][0]['protection']['drmEnabled']
         else:
             stream['hls_url'] = data_dict['attributes']['streaming']['hls']['url']

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -20,6 +20,7 @@ try:  # Python 3
 except ImportError:  # Python 2
     from urllib import urlencode
 
+import requests
 
 class KodiHelper(object):
     def __init__(self, base_url=None, handle=None):
@@ -261,7 +262,18 @@ class KodiHelper(object):
                     playitem.setProperty('inputstream.adaptive.license_key',
                                          stream['license_url'] + '|' + header + '|R{SSM}|')
             else:
-                playitem = xbmcgui.ListItem(path=stream['hls_url'])
+                url = stream['hls_url']
+                
+                if self.get_setting('locale') == 'en_US':
+                    originalm3u8 = requests.get(url).text
+                    updatedm3u8 = originalm3u8.replace("30.000", "29.970")
+                    tempm3u8 = open(self.addon_profile+'temp.m3u8', "w")
+                    tempm3u8.write(updatedm3u8)
+                    tempm3u8.close()
+                    tempm3u8path = self.addon_profile.replace("\\", "/") #replace backslashes in path with frontslashes on windows or ISA fails to load path
+                    playitem = xbmcgui.ListItem(path=tempm3u8path+'temp.m3u8')
+                else:
+                    playitem = xbmcgui.ListItem(path=stream['hls_url'])
 
                 if useIsa:
                     # Kodi 19 Matrix or higher

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -20,7 +20,6 @@ try:  # Python 3
 except ImportError:  # Python 2
     from urllib import urlencode
 
-import requests
 
 class KodiHelper(object):
     def __init__(self, base_url=None, handle=None):
@@ -262,18 +261,7 @@ class KodiHelper(object):
                     playitem.setProperty('inputstream.adaptive.license_key',
                                          stream['license_url'] + '|' + header + '|R{SSM}|')
             else:
-                url = stream['hls_url']
-                
-                if self.get_setting('locale') == 'en_US':
-                    originalm3u8 = requests.get(url).text
-                    updatedm3u8 = originalm3u8.replace("30.000", "29.970")
-                    tempm3u8 = open(self.addon_profile+'temp.m3u8', "w")
-                    tempm3u8.write(updatedm3u8)
-                    tempm3u8.close()
-                    tempm3u8path = self.addon_profile.replace("\\", "/") #replace backslashes in path with frontslashes on windows or ISA fails to load path
-                    playitem = xbmcgui.ListItem(path=tempm3u8path+'temp.m3u8')
-                else:
-                    playitem = xbmcgui.ListItem(path=stream['hls_url'])
+                playitem = xbmcgui.ListItem(path=stream['hls_url'])
 
                 if useIsa:
                     # Kodi 19 Matrix or higher


### PR DESCRIPTION
The m3u8 from discoveryplus.com says the refresh rate is 30.000, although it's actually 29.970. Because of this, about 5 seconds after the video starts playing, the screen goes black for a second as Kodi detects the wrong refresh rate and changes the video player to 29.970 fps from 30.000. It also does this about 5 seconds before where a commercial break would be and also 5 seconds after.

This downloads the m3u8 and replaces 30.000 with 29.970. It's a bit hacky but I can't think of a different way to do it. Not sure if other regions suffer from this or only US.