### PR TITLE
fixes a couple issues with resume/completed episodes

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -473,7 +473,7 @@ def list_page_us(page_path, search_query=None):
                                                                                         'name'),
                                                                                     'plot': channel['attributes'].get(
                                                                                         'description'),
-                                                                                    'playcount': '0'
+                                                                                    'playcount': 0
                                                                                 }
 
                                                                                 channel_logo = None
@@ -774,7 +774,7 @@ def list_page_in(page_path):
                                                                                  'attributes'].get('name'),
                                                                     'plot': channel['attributes'].get(
                                                                         'description'),
-                                                                    'playcount': '0'
+                                                                    'playcount': 0
                                                                 }
 
                                                                 channel_logo = None
@@ -942,7 +942,7 @@ def list_page(page_path):
                                                                                  'attributes'].get('name'),
                                                                     'plot': channel['attributes'].get(
                                                                         'description'),
-                                                                    'playcount': '0'
+                                                                    'playcount': 0
                                                                 }
 
                                                                 channel_logo = None
@@ -1083,7 +1083,7 @@ def list_page(page_path):
                                                                                      'attributes'].get('name'),
                                                                         'plot': channel['attributes'].get(
                                                                             'description'),
-                                                                        'playcount': '0'
+                                                                        'playcount': 0
                                                                     }
 
                                                                     channel_logo = None
@@ -1846,15 +1846,15 @@ def list_collection_items(collection_id, page_path=None):
                                         if helper.get_setting('sync_playback'):
                                             if video['attributes']['viewingHistory']['viewed']:
                                                 if video['attributes']['viewingHistory'].get('completed'):  # Watched video
-                                                    episode_info['playcount'] = '1'
+                                                    episode_info['playcount'] = 1
                                                     resume = 0
                                                     total = duration
                                                 else:  # Partly watched video
-                                                    episode_info['playcount'] = '0'
+                                                    episode_info['playcount'] = 0
                                                     resume = video['attributes']['viewingHistory']['position'] / 1000.0
                                                     total = duration
                                             else:  # Unwatched video
-                                                episode_info['playcount'] = '0'
+                                                episode_info['playcount'] = 0
                                                 resume = 0
                                                 total = 1
                                         else:  # Kodis resume data used
@@ -1937,7 +1937,7 @@ def list_collection_items(collection_id, page_path=None):
                                                 'title': helper.language(30014) + ' ' + channel['attributes'].get(
                                                     'name'),
                                                 'plot': channel['attributes'].get('description'),
-                                                'playcount': '0'
+                                                'playcount': 0
                                             }
 
                                             channel_logo = None
@@ -2363,15 +2363,15 @@ def list_favorite_watchlist_videos_in(videoType=None, playlist=None):
         if helper.get_setting('sync_playback'):
             if video['attributes']['viewingHistory']['viewed']:
                 if video['attributes']['viewingHistory']['completed']:  # Watched video
-                    episode_info['playcount'] = '1'
+                    episode_info['playcount'] = 1
                     resume = 0
                     total = duration
                 else:  # Partly watched video
-                    episode_info['playcount'] = '0'
+                    episode_info['playcount'] = 0
                     resume = video['attributes']['viewingHistory']['position'] / 1000.0
                     total = duration
             else:  # Unwatched video
-                episode_info['playcount'] = '0'
+                episode_info['playcount'] = 0
                 resume = 0
                 total = 1
         else:  # Kodis resume data used
@@ -2630,17 +2630,17 @@ def list_collection(collection_id, page, mandatoryParams=None, parameter=None):
                                 if helper.get_setting('sync_playback'):
                                     if video['attributes']['viewingHistory']['viewed']:
                                         if video['attributes']['viewingHistory']['completed']:  # Watched video
-                                            episode_info['playcount'] = '1'
+                                            episode_info['playcount'] = 1
                                             resume = 0
                                             total = duration
                                         else:  # Partly watched video
-                                            episode_info['playcount'] = '0'
+                                            episode_info['playcount'] = 0
                                             resume = video['attributes']['viewingHistory']['position'] / 1000.0
                                             total = duration
                                     else:  # Unwatched video
-                                        episode_info['playcount'] = '0'
+                                        episode_info['playcount'] = 0
                                         resume = 0
-                                        total = 1
+                                        total = duration
                                 else:  # Kodis resume data used
                                     resume = None
                                     total = None

--- a/addon.py
+++ b/addon.py
@@ -473,7 +473,7 @@ def list_page_us(page_path, search_query=None):
                                                                                         'name'),
                                                                                     'plot': channel['attributes'].get(
                                                                                         'description'),
-                                                                                    'playcount': 0
+                                                                                    'playcount': '0'
                                                                                 }
 
                                                                                 channel_logo = None
@@ -774,7 +774,7 @@ def list_page_in(page_path):
                                                                                  'attributes'].get('name'),
                                                                     'plot': channel['attributes'].get(
                                                                         'description'),
-                                                                    'playcount': 0
+                                                                    'playcount': '0'
                                                                 }
 
                                                                 channel_logo = None
@@ -942,7 +942,7 @@ def list_page(page_path):
                                                                                  'attributes'].get('name'),
                                                                     'plot': channel['attributes'].get(
                                                                         'description'),
-                                                                    'playcount': 0
+                                                                    'playcount': '0'
                                                                 }
 
                                                                 channel_logo = None
@@ -1083,7 +1083,7 @@ def list_page(page_path):
                                                                                      'attributes'].get('name'),
                                                                         'plot': channel['attributes'].get(
                                                                             'description'),
-                                                                        'playcount': 0
+                                                                        'playcount': '0'
                                                                     }
 
                                                                     channel_logo = None
@@ -1846,15 +1846,15 @@ def list_collection_items(collection_id, page_path=None):
                                         if helper.get_setting('sync_playback'):
                                             if video['attributes']['viewingHistory']['viewed']:
                                                 if video['attributes']['viewingHistory'].get('completed'):  # Watched video
-                                                    episode_info['playcount'] = 1
+                                                    episode_info['playcount'] = '1'
                                                     resume = 0
                                                     total = duration
                                                 else:  # Partly watched video
-                                                    episode_info['playcount'] = 0
+                                                    episode_info['playcount'] = '0'
                                                     resume = video['attributes']['viewingHistory']['position'] / 1000.0
                                                     total = duration
                                             else:  # Unwatched video
-                                                episode_info['playcount'] = 0
+                                                episode_info['playcount'] = '0'
                                                 resume = 0
                                                 total = 1
                                         else:  # Kodis resume data used
@@ -1937,7 +1937,7 @@ def list_collection_items(collection_id, page_path=None):
                                                 'title': helper.language(30014) + ' ' + channel['attributes'].get(
                                                     'name'),
                                                 'plot': channel['attributes'].get('description'),
-                                                'playcount': 0
+                                                'playcount': '0'
                                             }
 
                                             channel_logo = None
@@ -2363,15 +2363,15 @@ def list_favorite_watchlist_videos_in(videoType=None, playlist=None):
         if helper.get_setting('sync_playback'):
             if video['attributes']['viewingHistory']['viewed']:
                 if video['attributes']['viewingHistory']['completed']:  # Watched video
-                    episode_info['playcount'] = 1
+                    episode_info['playcount'] = '1'
                     resume = 0
                     total = duration
                 else:  # Partly watched video
-                    episode_info['playcount'] = 0
+                    episode_info['playcount'] = '0'
                     resume = video['attributes']['viewingHistory']['position'] / 1000.0
                     total = duration
             else:  # Unwatched video
-                episode_info['playcount'] = 0
+                episode_info['playcount'] = '0'
                 resume = 0
                 total = 1
         else:  # Kodis resume data used
@@ -2630,17 +2630,17 @@ def list_collection(collection_id, page, mandatoryParams=None, parameter=None):
                                 if helper.get_setting('sync_playback'):
                                     if video['attributes']['viewingHistory']['viewed']:
                                         if video['attributes']['viewingHistory']['completed']:  # Watched video
-                                            episode_info['playcount'] = 1
+                                            episode_info['playcount'] = '1'
                                             resume = 0
                                             total = duration
                                         else:  # Partly watched video
-                                            episode_info['playcount'] = 0
+                                            episode_info['playcount'] = '0'
                                             resume = video['attributes']['viewingHistory']['position'] / 1000.0
                                             total = duration
                                     else:  # Unwatched video
-                                        episode_info['playcount'] = 0
+                                        episode_info['playcount'] = '0'
                                         resume = 0
-                                        total = duration
+                                        total = 1
                                 else:  # Kodis resume data used
                                     resume = None
                                     total = None

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -150,11 +150,11 @@ class KodiHelper(object):
         if resume:
             listitem.setProperty("ResumeTime", str(resume))
             listitem.setProperty("TotalTime", str(total))
-            rpccmd = json.dumps({"jsonrpc": "2.0", "method": "Files.SetFileDetails",
-                                 "params": {"file": self.base_url + '?' + urlencode(params), "media": "video",
-                                            "resume": {"position": resume, "total": total}}, "id": "1"})
-            result = xbmc.executeJSONRPC(rpccmd)
-            self.log('rpc result: %s' % json.loads(result))
+            #rpccmd = json.dumps({"jsonrpc": "2.0", "method": "Files.SetFileDetails",
+            #                     "params": {"file": self.base_url + '?' + urlencode(params), "media": "video",
+            #                                "resume": {"position": resume, "total": total}}, "id": "1"})
+            #result = xbmc.executeJSONRPC(rpccmd)
+            #self.log('rpc result: %s' % json.loads(result))
         if art:
             listitem.setArt(art)
         else:

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -150,11 +150,6 @@ class KodiHelper(object):
         if resume:
             listitem.setProperty("ResumeTime", str(resume))
             listitem.setProperty("TotalTime", str(total))
-            #rpccmd = json.dumps({"jsonrpc": "2.0", "method": "Files.SetFileDetails",
-            #                     "params": {"file": self.base_url + '?' + urlencode(params), "media": "video",
-            #                                "resume": {"position": resume, "total": total}}, "id": "1"})
-            #result = xbmc.executeJSONRPC(rpccmd)
-            #self.log('rpc result: %s' % json.loads(result))
         if art:
             listitem.setArt(art)
         else:


### PR DESCRIPTION
Kodi wants playcount as an int, not str so previously if you finished an episode on the website, it wouldn't properly reflect as watched in Kodi. Also removed the jsonrpc to update the resume time since it doesn't appear to be needed anymore. Not sure if something changed in kodi, but I know when testing the US version, if jsonrpc wasn't used to set the resume time, it wouldn't resume properly. Lately I've been having an issue where if I watched part on the website and then went to Kodi, it wouldn't show the episode thumbnail or any info about the episode. Removing the jsonrpc resolve that issue and the episodes still resume at the proper time.