### PR TITLE
correct url for canada

### DIFF
--- a/resources/lib/dplay.py
+++ b/resources/lib/dplay.py
@@ -48,7 +48,7 @@ class Dplay(object):
                 'x-disco-params': 'realm=dplay,siteLookupKey=dplus_uk,bid=dplus,hn=www.discoveryplus.com,hth=gb,features=ar',
                 'x-disco-client': 'WEB:UNKNOWN:dplus_us:1.25.0'
             }
-        elif self.locale_suffix == 'us':
+        elif self.locale_suffix in ['us', 'ca']:
             self.api_url = 'https://us1-prod-direct.discoveryplus.com'
             self.realm = 'go'
             self.contentRatingSystem = 'BLM'


### PR DESCRIPTION
I wasn't able to log in to Canadian d+, and figured out Canada uses the US url. Not sure if this is the best place for it to be set or not, but it's working for me.